### PR TITLE
IWPFDependencyObjectCollectionをEnumerableに変換する拡張メソッドを追加

### DIFF
--- a/Project/RM.Friendly.WPFStandardControls.3.5/RM.Friendly.WPFStandardControls.3.5.csproj
+++ b/Project/RM.Friendly.WPFStandardControls.3.5/RM.Friendly.WPFStandardControls.3.5.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Compile Include="ButtonSearcherExtensions.cs" />
     <Compile Include="ButtonSearcherInTargetExtensions.cs" />
+    <Compile Include="WPFCollectionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SearcherExtensions.cs" />
     <Compile Include="SearcherInTargetExtensions.cs" />

--- a/Project/RM.Friendly.WPFStandardControls.3.5/WPFCollectionExtensions.cs
+++ b/Project/RM.Friendly.WPFStandardControls.3.5/WPFCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿using Codeer.Friendly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+
+namespace RM.Friendly.WPFStandardControls
+{
+#if ENG
+    /// <summary>
+    /// IWPFDependencyObjectCollection utility.
+    /// </summary>
+#else
+    /// <summary>
+    /// IWPFDependencyObjectCollectionのユーティリティー。
+    /// </summary>
+#endif
+    public static class WPFCollectionExtensions
+    {
+#if ENG
+        /// <summary>
+        /// Make IWPFDependencyObjectCollection enumerable.
+        /// </summary>
+        /// <typeparam name="T">The enumerating object type.</typeparam>
+        /// <param name="self">IWPFDependencyObjectCollection object.</param>
+        /// <returns>The object which converted enumerable.</returns>
+#else
+        /// <summary>
+        /// IWPFDependencyObjectCollectionを列挙可能な型に変換する。
+        /// </summary>
+        /// <typeparam name="T">反復するオブジェクトの型。</typeparam>
+        /// <param name="self">IWPFDependencyObjectCollectionオブジェクト。</param>
+        /// <returns>列挙可能な形式に変換されたオブジェクト。</returns>
+#endif
+        public static IEnumerable<AppVar> ToEnumerable<T>(this IWPFDependencyObjectCollection<T> self) where T : DependencyObject
+        {
+            for (int i = 0; i < self.Count; i++)
+            {
+                yield return self[i];
+            }
+        }
+    }
+}

--- a/Project/Test/EnumerableTest.cs
+++ b/Project/Test/EnumerableTest.cs
@@ -1,0 +1,57 @@
+﻿using Codeer.Friendly;
+using Codeer.Friendly.Dynamic;
+using Codeer.Friendly.Windows;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RM.Friendly.WPFStandardControls;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Test
+{
+    [TestClass]
+    public class EnumerableTest
+    {
+        WindowsAppFriend app;
+        dynamic win;
+        dynamic control;
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            app = new WindowsAppFriend(Process.Start("Target.exe"));
+            WindowsAppExpander.LoadAssembly(app, GetType().Assembly);
+            win = app.Type(typeof(Application)).Current.MainWindow;
+            dynamic grid = win._grid;
+            control = app.Type<EnumerableTestControl>()();
+            grid.Children.Add(control);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Process.GetProcessById(app.ProcessId).Kill();
+        }
+
+        [TestMethod]
+        public void LinqSingleTest()
+        {
+            var ctrl = ((AppVar)control).LogicalTree().ByType<TextBlock>().ToEnumerable().Single(el => (string)el.Dynamic().Text == "and");
+            ctrl.Dynamic().Text = "or";
+            Assert.AreEqual((string)((AppVar)control).LogicalTree().ByType<TextBlock>()[1].Dynamic().Text, "or");
+        }
+
+        [TestMethod]
+        public void LinqAnyTest()
+        {
+            var isByeExists = ((AppVar)control).LogicalTree().ByType<TextBlock>().ToEnumerable().Any(el => (bool)el.Dynamic().Text.Contains("bye"));
+            var isAppleExists = ((AppVar)control).LogicalTree().ByType<TextBlock>().ToEnumerable().Any(el => (bool)el.Dynamic().Text.Contains("apple"));
+            Assert.IsTrue(isByeExists);
+            Assert.IsFalse(isAppleExists);
+        }
+    }
+}

--- a/Project/Test/EnumerableTestControl.xaml
+++ b/Project/Test/EnumerableTestControl.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Test.EnumerableTestControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Test"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <TextBlock Text="Hello"/>
+        <TextBlock Text="and"/>
+        <TextBlock Text="Good bye"/>
+    </Grid>
+</UserControl>

--- a/Project/Test/EnumerableTestControl.xaml.cs
+++ b/Project/Test/EnumerableTestControl.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Test
+{
+    /// <summary>
+    /// EnumerableTestControl.xaml の相互作用ロジック
+    /// </summary>
+    public partial class EnumerableTestControl : UserControl
+    {
+        public EnumerableTestControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Project/Test/Test.csproj
+++ b/Project/Test/Test.csproj
@@ -92,6 +92,10 @@
       <DependentUpon>ButtonSearchTestControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="DelegateCommand.cs" />
+    <Compile Include="EnumerableTest.cs" />
+    <Compile Include="EnumerableTestControl.xaml.cs">
+      <DependentUpon>EnumerableTestControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ListBox.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SearchTest.cs" />
@@ -177,6 +181,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="ButtonSearchTestControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="EnumerableTestControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
VisualTreeやLogicalTreeから得られるIWPFDependencyObjectCollectionにLinqやforeachを使いたかったのですが使えなかったので、拡張メソッドを作成しました。

本当はIWPFDependencyObjectCollectionにIEnumerableを継承したかったのですが、既存のインターフェースの設計変更をためらってしまったのと、共変性のあるインターフェースは他の型変数を伴うインターフェースを継承できない様子だったので、拡張メソッドという形にしました。

ご検討よろしくお願いいたします。