### PR TITLE
WPFTreeView.GetItem呼び出しの安定性を向上

### DIFF
--- a/Project/RM.Friendly.WPFStandardControls.3.0/Inside/WPFTreeViewReflection.cs
+++ b/Project/RM.Friendly.WPFStandardControls.3.0/Inside/WPFTreeViewReflection.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace RM.Friendly.WPFStandardControls.Inside
+{
+    internal static class WPFTreeViewReflection
+    {
+        private static PropertyInfo _itemsHostProperty = null;
+        private static PropertyInfo _disconnectedSourceProperty = null;
+
+        public static Panel GetItemsHostFor(TreeViewItem item)
+        {
+            var propertyInfo = _itemsHostProperty ?? (_itemsHostProperty = typeof(TreeViewItem).GetProperty(
+                "ItemsHost", BindingFlags.NonPublic | BindingFlags.Instance));
+            return (Panel)propertyInfo.GetValue(item, null);
+        }
+
+        public static object GetDisconnectedSource()
+        {
+            var propertyInfo = _disconnectedSourceProperty ?? (_disconnectedSourceProperty = typeof(BindingOperations).GetProperty(
+                "DisconnectedSource", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic));
+            return propertyInfo.GetValue(null, null);
+        }
+    }
+}

--- a/Project/RM.Friendly.WPFStandardControls.3.0/RM.Friendly.WPFStandardControls.3.0.csproj
+++ b/Project/RM.Friendly.WPFStandardControls.3.0/RM.Friendly.WPFStandardControls.3.0.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <Compile Include="AppVarWrapper.cs" />
     <Compile Include="AppVarWrapper.Partial.cs" />
+    <Compile Include="Inside\WPFTreeViewReflection.cs" />
     <Compile Include="TextBlockSearcher.cs" />
     <Compile Include="TextBlockSearcherInTarget.cs" />
     <Compile Include="FrameworkElementSearcher.cs" />

--- a/Project/RM.Friendly.WPFStandardControls.3.0/WPFTreeView.cs
+++ b/Project/RM.Friendly.WPFStandardControls.3.0/WPFTreeView.cs
@@ -1,18 +1,13 @@
 ﻿using Codeer.Friendly;
-using Codeer.Friendly.Windows;
 using Codeer.TestAssistant.GeneratorToolKit;
 using RM.Friendly.WPFStandardControls.Inside;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Threading;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 

--- a/Project/RM.Friendly.WPFStandardControls.3.0/WPFTreeView.cs
+++ b/Project/RM.Friendly.WPFStandardControls.3.0/WPFTreeView.cs
@@ -4,11 +4,15 @@ using Codeer.TestAssistant.GeneratorToolKit;
 using RM.Friendly.WPFStandardControls.Inside;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 
@@ -165,7 +169,24 @@ namespace RM.Friendly.WPFStandardControls
             }
         }
 
-        static TreeViewItem GetItemAndScrollIntoView(TreeView tree, ItemsControl parent, int i)
+        static TreeViewItem GetItemAndScrollIntoView(TreeView treeView, ItemsControl parent, int i)
+        {
+            var isVirtualized = VirtualizingStackPanel.GetIsVirtualizing(treeView);
+            return isVirtualized
+                ? GetItemAndScrollIntoViewForVirtualized(treeView, parent, i)
+                : GetItemAndScrollIntoViewForNonVirtualized(treeView, parent, i);
+        }
+
+        static TreeViewItem GetItemAndScrollIntoViewForNonVirtualized(TreeView treeView, ItemsControl parent, int i)
+        {
+            // 仮想化されていないので常にとれる
+            var container = (TreeViewItem)parent.ItemContainerGenerator.ContainerFromIndex(i);
+            container.BringIntoView();
+            InvokeUtility.DoEvents();
+            return container;
+        }
+
+        static TreeViewItem GetItemAndScrollIntoViewForVirtualized(TreeView tree, ItemsControl parent, int i)
         {
             var box = VisualTreeHelper.GetDescendantBounds(tree);
 
@@ -182,8 +203,14 @@ namespace RM.Friendly.WPFStandardControls
                 {
                     item.BringIntoView();
                     InvokeUtility.DoEvents();
+                    // 時々スクロールしすぎるあるらしい。item.DataContextがDisconnectedになってる時はもう一回やりなおす。
+                    if(item.DataContext == WPFTreeViewReflection.GetDisconnectedSource())
+                    {
+                        continue;
+                    }
                     var top = item.TranslatePoint(new Point(), tree);
-                    if (box.Contains(new Point(box.X, top.Y + item.ActualHeight / 2)))
+                    // TreeViewItemのActualHeightはItemsHost(子要素)を含んだ高さを返すので、ItemsHostを除いた高さで評価する
+                    if (box.Contains(new Point(box.X, top.Y + (item.ActualHeight - GetItemsHostHeight(item)) / 2)))
                     {
                         return item;
                     }
@@ -218,9 +245,21 @@ namespace RM.Friendly.WPFStandardControls
                     if (item != null) return item;
                 }
 
+                var now = DateTime.Now;
+                var current = scrollProvider.VerticalScrollPercent;
                 scrollProvider.Scroll(ScrollAmount.NoAmount, direction);
                 InvokeUtility.DoEvents();
+                while (DateTime.Now - now < TimeSpan.FromSeconds(1)
+                    && current == scrollProvider.VerticalScrollPercent)
+                {
+                    InvokeUtility.DoEvents();
+                }
             }
+        }
+
+        static double GetItemsHostHeight(TreeViewItem item)
+        {
+            return WPFTreeViewReflection.GetItemsHostFor(item)?.ActualHeight ?? 0;
         }
 
         static TreeViewItem[] GetTreeChildren(DependencyObject control, int index)


### PR DESCRIPTION
## 目的

WPFTreeView.GetItemがなかなか成功しないので安定性を向上する。

## 作戦

TreeViewの仮想化状態に応じてGetItemの作戦を2パターン用意する

### 非仮想化TreeView向け

仮想化されていない場合は`ItemContainerGenerator`で常にコンテナが取得できることから、`BringIntoView()` が安定して成功する。

このため、BringIntoView + DoEvents で画面内へ移動させ、要素へアクセスする。

### 仮想化TreeView向け

仮想化TreeViewの場合は`ItemContainerGenerator`がnullを返すことがある。
そのため基本的にはこれまで通り、対象が画面内に表示されるまでスクロールを続け、TreeViewItemのインスタンスが取れればそれをターゲットとする。

この処理に不具合のような挙動があったため修正した。

1. TreeViewItemのActualHeightを求めその 1/2 の高さの点が画面内に存在しているかを判定しているが、このActualHeightには子要素を表示するItemsHostを含んでいるため表示状態が正しく判定されないことがある。
    - ActualHeightからItemsHost分を除いた高さで判定するように変更した
2. `ItemContainerGenerator`から得られた要素にたいして、`BringIntoView`を呼び出した結果なぜか画面外へすっ飛んでいき、その後仮想化によって要素が解放されることがある。
    - 解放されたTreeViewItemはDataContextに特殊な値が設定されているので、特殊な値だった場合は再度検索をやり直すように変更した
